### PR TITLE
Fixed swapped cache methods

### DIFF
--- a/source/Utils/MSALPerUserSessionTokenCache.cs
+++ b/source/Utils/MSALPerUserSessionTokenCache.cs
@@ -178,8 +178,12 @@ namespace Microsoft_Teams_Graph_RESTAPIs_Connect
         /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
         private void UserTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
         {
-            this.LoadUserTokenCacheFromSession();
-        }
+			// if the access operation resulted in a cache update
+			if (args.HasStateChanged)
+			{
+				this.PersistUserTokenCache();
+			}
+		}
 
         /// <summary>
         /// Triggered right before MSAL needs to access the cache. Reload the cache from the persistence store in case it changed since the last access.
@@ -187,12 +191,8 @@ namespace Microsoft_Teams_Graph_RESTAPIs_Connect
         /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
         private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
         {
-            // if the access operation resulted in a cache update
-            if (args.HasStateChanged)
-            {
-                this.PersistUserTokenCache();
-            }
-        }
+			this.LoadUserTokenCacheFromSession();
+		}
 
         /// <summary>
         /// Explores the Claims of a signed-in user (if available) to populate the unique Id of this cache's instance.


### PR DESCRIPTION
As an urgent hotfix, I have fixed UserTokenCacheAfterAccessNotification and UserTokenCacheBeforeAccessNotification swapped implementations.

Jean-Marc suggested to improve our .NET 4.X cache providers according to the latest changes on microsoft-authentication-extensions-for-dotnet but since this will require more time, I would like to do this quick hotfix first to prevent developers of cloning a wrong class as soon as possible.
